### PR TITLE
[veglenker_v2] Add veglenker_v2 example queries.

### DIFF
--- a/notebooks/bigquery:nvdb.standardized.veglenker_v2.ipynb
+++ b/notebooks/bigquery:nvdb.standardized.veglenker_v2.ipynb
@@ -1,0 +1,441 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ],
+        "id": "LGtI9xoV49YD"
+      },
+      "outputs": [],
+      "source": [
+        "project = 'saga-nvdb-prod-vlmh'\n",
+        "use_colab_auth = True\n",
+        "\n",
+        "# Legg inn ditt eget prosjekt her, f.eks. 'saga-olanor-playground-ab12'\n",
+        "bq_job_project = ''"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6hzoTK1d49YH"
+      },
+      "outputs": [],
+      "source": [
+        "if (use_colab_auth):\n",
+        "  from google.colab import auth\n",
+        "  auth.authenticate_user()\n",
+        "  print('Authenticated')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aSlMTIlr49YH"
+      },
+      "outputs": [],
+      "source": [
+        "import warnings\n",
+        "from google.cloud import bigquery\n",
+        "\n",
+        "warnings.filterwarnings('ignore')\n",
+        "client = bigquery.Client(project=bq_job_project)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xGwwmIAF49YI"
+      },
+      "source": [
+        "Denne spørringen henter ut lengden på det nåværende vegnettet for riks- og europaveg i Norge.\n",
+        "\n",
+        "Uttrekket ser på en forenklet utgave av europa- og riksvegnettet for kjørende, der adskilte felt og løp bare er gitt i én retning.\n",
+        "Dette gir en lengde for hovedårene i vegnettet men inkluderer da altså ikke lengdene for hvert kjørefelt, og heller ikke sideanlegg slik som gang- og sykkelveg."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vxpad3OC49YK"
+      },
+      "outputs": [],
+      "source": [
+        "query = f\"\"\"\n",
+        "SELECT\n",
+        "  SUM(ST_LENGTH(geometri.wkt))/1000 vegnettKm\n",
+        "FROM\n",
+        "  `{project}.standardized.veglenker_v2`\n",
+        "WHERE\n",
+        "  # Nåværende vegnett\n",
+        "  (metadata.sluttdato IS NULL OR metadata.sluttdato >= CURRENT_DATE())\n",
+        "\n",
+        "  # Hovedtrase\n",
+        "  AND type = \"HOVED\"\n",
+        "\n",
+        "  # Europaveg og Riksveg\n",
+        "  AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "  # Eksisterende veg som er del av det operative vegnettet\n",
+        "  AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "  # Behold bare ett løp for adskilte tunelløp\n",
+        "  AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "  AND typeVeg IN (\n",
+        "    \"Rundkjøring\",\n",
+        "    \"Enkel bilveg\",\n",
+        "    \"Kanalisert veg\",\n",
+        "    \"Rampe\");\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "client.query(query).to_dataframe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LQjPKHa349YK"
+      },
+      "source": [
+        "Denne spørringen henter ut det nåværende vegnettet for riks- og europaveg i Trøndelag fylke.\n",
+        "\n",
+        "Uttrekket viser en forenklet utgave av europa- og riksvegnettet for kjørende, der adskilte felt og løp bare er gitt i én retning.\n",
+        "Dette gir en oversikt over hvordan vegnettet overordnet ser ut, men unnlater en del detaljer, som feks hvor mange felt vegene har og hvor det finnes gang- og sykkelveg."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xyLm1lRR49YL"
+      },
+      "outputs": [],
+      "source": [
+        "query = f\"\"\"\n",
+        "SELECT\n",
+        "  vegsystemreferanse.kortform, veglenkesekvensid, veglenkenummer, segmentnummer, startposisjon, sluttposisjon, typeVeg, detaljnivaa, kommune, geometri.wkt\n",
+        "FROM\n",
+        "  `{project}.standardized.veglenker_v2`\n",
+        "WHERE\n",
+        "  # Trøndelag\n",
+        "  fylke = 50\n",
+        "\n",
+        "  # Nåværende vegnett\n",
+        "  AND (metadata.sluttdato IS NULL OR metadata.sluttdato >= CURRENT_DATE())\n",
+        "\n",
+        "  # Hovedtrase\n",
+        "  AND type = \"HOVED\"\n",
+        "\n",
+        "  # Europaveg og Riksveg\n",
+        "  AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "  # Eksisterende veg som er del av det operative vegnettet\n",
+        "  AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "  # Behold bare ett løp for adskilte tunelløp\n",
+        "  AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "  AND typeVeg IN (\n",
+        "    \"Rundkjøring\",\n",
+        "    \"Enkel bilveg\",\n",
+        "    \"Kanalisert veg\",\n",
+        "    \"Rampe\");\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "vegnettTrondelag = client.query(query).to_dataframe()\n",
+        "\n",
+        "vegnettTrondelag"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nVVqYEeS49YM"
+      },
+      "source": [
+        "Denne spørringen viser hvordan riks- og europavegnettet for et gitt tidspunkt kan hentes ut, med ellers samme filter som over."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "64xs9P7349YM"
+      },
+      "outputs": [],
+      "source": [
+        "query = f\"\"\"\n",
+        "SELECT\n",
+        "  vegsystemreferanse.kortform,\n",
+        "  geometri.wkt\n",
+        "FROM\n",
+        "  `{project}.standardized.veglenker_v2`\n",
+        "WHERE\n",
+        "  # Trøndelag\n",
+        "  fylke = 50\n",
+        "\n",
+        "  # Vegnett for et gitt tidspunkt\n",
+        "  AND (\n",
+        "      # Opprettet før det aktuelle tidspunktet\n",
+        "      metadata.startdato < '2020-01-01'\n",
+        "      AND\n",
+        "      # Avsluttet etter tidspunktet eller er fortsatt aktiv\n",
+        "      (metadata.sluttdato >= '2020-01-01' OR metadata.sluttdato IS NULL)\n",
+        "  )\n",
+        "\n",
+        "  # Hovedtrase\n",
+        "  AND type = \"HOVED\"\n",
+        "\n",
+        "  # Europaveg og Riksveg\n",
+        "  AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "  # Eksisterende veg som er del av det operative vegnettet\n",
+        "  AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "  # Behold bare ett løp for adskilte tunelløp\n",
+        "  AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "  AND typeVeg IN (\n",
+        "    \"Rundkjøring\",\n",
+        "    \"Enkel bilveg\",\n",
+        "    \"Kanalisert veg\",\n",
+        "    \"Rampe\");\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "client.query(query).to_dataframe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3egySPo_49YN"
+      },
+      "source": [
+        "Denne spørringen viser hvordan vegeier og vegens navn kan utledes fra de andre feltene."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dIWEj7W749YN"
+      },
+      "outputs": [],
+      "source": [
+        "query = f\"\"\"\n",
+        "SELECT\n",
+        "  FORMAT(\"%s%s%d\",\n",
+        "    vegsystemreferanse.vegsystem.vegkategori,\n",
+        "    vegsystemreferanse.vegsystem.fase,\n",
+        "    vegsystemreferanse.vegsystem.nummer) vegnavn,\n",
+        "  IF(\n",
+        "    EXISTS(SELECT * FROM UNNEST(kontraktsomraader) WHERE REGEXP_CONTAINS(navn, \"NV_\")),\n",
+        "    \"Stat, Nye Veier\",\n",
+        "    \"Stat, Statens vegvesen\") vegeier,\n",
+        "FROM\n",
+        "  `{project}.standardized.veglenker_v2`\n",
+        "WHERE\n",
+        "  # Trøndelag\n",
+        "  fylke = 50\n",
+        "\n",
+        "  # Nåværende vegnett\n",
+        "  AND (metadata.sluttdato IS NULL OR metadata.sluttdato >= CURRENT_DATE())\n",
+        "\n",
+        "  # Hovedtrase\n",
+        "  AND type = \"HOVED\"\n",
+        "\n",
+        "  # Europaveg og Riksveg\n",
+        "  AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "  # Eksisterende veg som er del av det operative vegnettet\n",
+        "  AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "  # Behold bare ett løp for adskilte tunelløp\n",
+        "  AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "  AND typeVeg IN (\n",
+        "    \"Rundkjøring\",\n",
+        "    \"Enkel bilveg\",\n",
+        "    \"Kanalisert veg\",\n",
+        "    \"Rampe\");\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "client.query(query).to_dataframe()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4vXsDcux49YN"
+      },
+      "source": [
+        "Denne spørringen viser hvordan man kan avdekke veglenkesekvenser som ble blitt opprettet i perioden 2020-01-01 til 2021-01-01. Merk at spørringen returnerer alle veglenker i sekvensen, ikke bare de som ble opprettet i den aktuelle perioden."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CknWAXMd49YO"
+      },
+      "outputs": [],
+      "source": [
+        "query = f\"\"\"\n",
+        "WITH\n",
+        "veglenker AS\n",
+        "  (SELECT *\n",
+        "  FROM `{project}.standardized.veglenker_v2`\n",
+        "  WHERE\n",
+        "    # Hovedtrase\n",
+        "    type = \"HOVED\"\n",
+        "\n",
+        "    # Europaveg og Riksveg\n",
+        "    AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "    # Eksisterende veg som er del av det operative vegnettet\n",
+        "    AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "    # Behold bare ett løp for adskilte tunelløp\n",
+        "    AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "    AND typeVeg IN (\n",
+        "      \"Rundkjøring\",\n",
+        "      \"Enkel bilveg\",\n",
+        "      \"Kanalisert veg\",\n",
+        "      \"Rampe\")),\n",
+        "\n",
+        "nye_veglenkesekvenser AS\n",
+        "  (SELECT\n",
+        "    veglenkesekvensid,\n",
+        "    ST_UNION_AGG(geometri.wkt) geometri,\n",
+        "    MIN(metadata.startdato) AS tidligste_startdato\n",
+        "  FROM veglenker\n",
+        "  GROUP BY veglenkesekvensid\n",
+        "  HAVING\n",
+        "   # Sekvensen ble opprettet i perioden\n",
+        "   tidligste_startdato BETWEEN '2020-01-01' AND '2021-01-01')\n",
+        "\n",
+        "SELECT * FROM nye_veglenkesekvenser\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "client.query(query).to_dataframe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pnWptL2l49YO"
+      },
+      "source": [
+        "Denne spørringen viser hvordan man kan avdekke veglenkesekvenser som ble endelig avsluttet i perioden 2020-01-01 til 2021-01-01. Dette er en grei måte å få oversikt over større endringer i vegnettet, men den får ikke med seg de tilfeller hvor det blir avsluttet noen, men ikke alle, veglenker i en sekvens. [Se denne presentasjonen for mer informasjon om forholdet mellom veglenker og veglenkesekvenser.](https://vegvesen-my.sharepoint.com/:p:/g/personal/jan_kristian_jensen_vegvesen_no/ERTPmjdinZxIh23EwpQeigYBn_lFAzyJHuuisQyU4_qVhg)\n",
+        "\n",
+        "Merk at spørringen returnerer alle veglenker i sekvensen, ikke bare de som ble avsluttet i den aktuelle perioden."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b7YakeUP49YO"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "query = f\"\"\"\n",
+        "WITH\n",
+        "veglenker AS\n",
+        "  (SELECT *\n",
+        "  FROM `{project}.standardized.veglenker_v2`\n",
+        "  WHERE\n",
+        "    # Hovedtrase\n",
+        "    type = \"HOVED\"\n",
+        "\n",
+        "    # Europaveg og Riksveg\n",
+        "    AND vegsystemreferanse.vegsystem.vegkategori in (\"E\", \"R\")\n",
+        "\n",
+        "    # Eksisterende veg som er del av det operative vegnettet\n",
+        "    AND vegsystemreferanse.vegsystem.fase in (\"V\")\n",
+        "\n",
+        "    # Behold bare ett løp for adskilte tunelløp\n",
+        "    AND (vegsystemreferanse.strekning.adskilteLop IN (\"Med\", \"Nei\") OR vegsystemreferanse.strekning.adskilteLop IS NULL)\n",
+        "\n",
+        "    AND typeVeg IN (\n",
+        "      \"Rundkjøring\",\n",
+        "      \"Enkel bilveg\",\n",
+        "      \"Kanalisert veg\",\n",
+        "      \"Rampe\")),\n",
+        "\n",
+        "stengte_veglenkesekvenser AS\n",
+        "  (SELECT\n",
+        "    veglenkesekvensid,\n",
+        "    ST_UNION_AGG(geometri.wkt) geometri,\n",
+        "    COUNT(*) AS totalt_antall_veglenker,\n",
+        "    SUM(\n",
+        "      CASE\n",
+        "        WHEN metadata.sluttdato IS NOT NULL THEN 1\n",
+        "        ELSE 0\n",
+        "      END) antall_stengte_veglenker,\n",
+        "    MAX(metadata.sluttdato) AS siste_sluttdato\n",
+        "  FROM veglenker\n",
+        "  GROUP BY veglenkesekvensid\n",
+        "  HAVING\n",
+        "   # alle veglenkene i veglenkesekvensen er stengt\n",
+        "   totalt_antall_veglenker = antall_stengte_veglenker\n",
+        "   # siste sluttdato i perioden\n",
+        "   AND siste_sluttdato BETWEEN '2020-01-01' AND '2021-01-01')\n",
+        "\n",
+        "SELECT * FROM stengte_veglenkesekvenser\n",
+        "\"\"\"\n",
+        "\n",
+        "print(query)\n",
+        "\n",
+        "client.query(query).to_dataframe()"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "toc_visible": true
+    },
+    "interpreter": {
+      "hash": "76fc8d637562237ed9fa9f5fc55aea468a1db6da504bb7c6ed12752c17fcd7b9"
+    },
+    "kernelspec": {
+      "display_name": "Python 3.9.1 64-bit ('3.9.1')",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
A copy of the veglenker example queries, adjusted for veglenker_v2 where geometri has become geometri.wkt.